### PR TITLE
Change reportProjectInfo description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ kuronometer {
     //Config used to indicate the platform name. By default the value configured is Java.
     //This value can be 'Android', 'Java' or 'Scala' for now.
     platformName = 'Android'
-    //Config used to remove the project sensitive information before to being reported. By default is true.
+    //Config used to attach or not sensitive information before to being reported. By default is true.
     //This value can be true or false.
     reportProjectInfo = true
     //Config used to send or not the build report to the kuronometer server. By default is true.

--- a/kuronometer-android-consumer/app/build.gradle
+++ b/kuronometer-android-consumer/app/build.gradle
@@ -38,7 +38,7 @@ kuronometer {
     //Config used to indicate the platform name. By default the value configured is Java.
     //This value can be 'Android', 'Java' or 'Scala' for now.
     platformName = 'Android'
-    //Config used to remove the project sensitive information before to being reported. By default is true.
+    //Config used to attach or not sensitive information before to being reported. By default is true.
     //This value can be true or false.
     reportProjectInfo = true
     //Config used to send or not the build report to the kuronometer server. By default is true.

--- a/kuronometer-consumer/build.gradle
+++ b/kuronometer-consumer/build.gradle
@@ -32,7 +32,7 @@ kuronometer {
     //Config used to indicate the platform name. By default the value configured is Java.
     //This value can be 'Android', 'Java' or 'Scala' for now.
     platformName = 'Java'
-    //Config used to remove the project sensitive information before to being reported. By default is true.
+    //Config used to attach or not sensitive information before to being reported. By default is true.
     //This value can be true or false.
     reportProjectInfo = true
     //Config used to send or not the build report to the kuronometer server. By default is true.


### PR DESCRIPTION
Replace remove with attach, so both the config parameter value and the name have the same meaning. Previously they would have opposite meaning and the boolean value was misleading.