### PR TITLE
Improve performance

### DIFF
--- a/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/Kuronometer.scala
+++ b/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/Kuronometer.scala
@@ -5,7 +5,8 @@ import cats.implicits._
 import cats.free.Free
 import com.github.pedrovgs.kuronometer.KuronometerResults.{
   ConnectionError,
-  KuronometerResult
+  KuronometerResult,
+  UnknownError
 }
 import com.github.pedrovgs.kuronometer.free.algebra.{ReporterOps, ViewOps}
 import com.github.pedrovgs.kuronometer.free.domain.View.Message
@@ -93,6 +94,12 @@ object Kuronometer {
           _ <- V.showMessage(
             SummaryBuildStageExecutionFormatter.format(summary))
         } yield message
+      case Left(UnknownError(Some(t))) =>
+        V.showError(
+            "Kuronometer: Exception catch while gathering data related to your builds execution: " + t.getLocalizedMessage + ".\n")
+          .flatMap(_ =>
+            V.showError(
+              "Try cleaning your project executing \"./gradlew clean\". If this doesn't fix your problem open an issue in the project GitHub repository https://github.com/pedrovgs/kuronometer"))
       case Left(_) =>
         V.showError(
           "Kuronometer: Error gathering data related to your builds execution.")

--- a/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/KuronometerResults.scala
+++ b/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/KuronometerResults.scala
@@ -6,6 +6,6 @@ object KuronometerResults {
 
   sealed trait KuronometerError
   case object ConnectionError extends KuronometerError
-  case object UnknownError extends KuronometerError
+  case class UnknownError(t: Option[Throwable] = None) extends KuronometerError
 
 }

--- a/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClient.scala
+++ b/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClient.scala
@@ -36,7 +36,8 @@ class KuronometerApiClient {
         .postData(body)
         .asString)
       .map(response =>
-        if (response.isSuccess) Right(buildExecution) else Left(UnknownError))
+        if (response.isSuccess) Right(buildExecution)
+        else Left(UnknownError()))
       .toOption
       .getOrElse(Left(ConnectionError))
   }

--- a/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/csv/CsvReporter.scala
+++ b/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/csv/CsvReporter.scala
@@ -39,7 +39,6 @@ class CsvReporter {
 
   def getBuildExecutionStagesSinceTimestamp(filterTimestamp: Long)
     : KuronometerResult[SummaryBuildStagesExecution] = {
-    //TODO: Use ICsvDozerBeanReader for reading and writing.
     if (!existsReportFile || reportFileIsEmpty) {
       emptySummary
     } else {

--- a/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClientSpec.scala
+++ b/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClientSpec.scala
@@ -42,7 +42,7 @@ class KuronometerApiClientSpec
 
     val result = report()
 
-    result shouldBe Left(UnknownError)
+    result shouldBe Left(UnknownError())
   }
 
   it should "send the build execution as part of the report request serialized into json" in {

--- a/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/generators/KuronometerErrorGenerators.scala
+++ b/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/generators/KuronometerErrorGenerators.scala
@@ -12,6 +12,6 @@ object KuronometerErrorGenerators {
   implicit val arbKuronometerError: Arbitrary[KuronometerError] = Arbitrary(
     error)
 
-  def error: Gen[KuronometerError] = Gen.oneOf(ConnectionError, UnknownError)
+  def error: Gen[KuronometerError] = Gen.oneOf(ConnectionError, UnknownError())
 
 }


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #7 

### :tophat: What is the goal?

Improve the application performance when reading long report files. We've noticed that reading a 9MB file with 158456 build execution stages inside our application needed about 3 minutes and 55 seconds to calculate the total build time. [Here](http://docs.scala-lang.org/overviews/collections/performance-characteristics.html) you can find some useful information about the Scala collections performance.

### How is it being implemented?

The performance improvements implemented are:

* Parallelize the mapping between ``CsvBuildStageExecution`` instances and ``BuildStageExecution`` instances performed inside the ``CsvReporter`` class.
* Change the collection being used in the recursive algorithm needed to read the build stages execution from the ``csv`` file. We changed from a ``Seq`` to a ``ListBuffer``. **The usage of focused mutability, in this case, seriously improves our software performance.**

We've also updated how we represent errors inside the app adding information about the exception catch. The error message shown to the user has been updated as well.

### How can it be tested?

Generate a really long ``tasksExecutionTimes.csv`` file and execute ``./gradlew totalBuildTime`` or ``./gradlew todayBuildTime``. The execution time should be dramatically decreased.