### PR TITLE
Change the API client port configured

### DIFF
--- a/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClient.scala
+++ b/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClient.scala
@@ -43,6 +43,10 @@ class KuronometerApiClient {
   }
 
   private def composeUrl(path: String)(
-      implicit apiClientConfig: KuronometerApiClientConfig): String =
-    apiClientConfig.scheme + "://" + apiClientConfig.host + ":" + apiClientConfig.port + path
+      implicit apiClientConfig: KuronometerApiClientConfig): String =  apiClientConfig.port match {
+    case Some(port) => apiClientConfig.scheme + "://" + apiClientConfig.host + ":" + port + path
+    case _ => apiClientConfig.scheme + "://" + apiClientConfig.host + path
+  }
+
+
 }

--- a/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClient.scala
+++ b/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClient.scala
@@ -43,10 +43,11 @@ class KuronometerApiClient {
   }
 
   private def composeUrl(path: String)(
-      implicit apiClientConfig: KuronometerApiClientConfig): String =  apiClientConfig.port match {
-    case Some(port) => apiClientConfig.scheme + "://" + apiClientConfig.host + ":" + port + path
-    case _ => apiClientConfig.scheme + "://" + apiClientConfig.host + path
-  }
-
+      implicit apiClientConfig: KuronometerApiClientConfig): String =
+    apiClientConfig.port match {
+      case Some(port) =>
+        apiClientConfig.scheme + "://" + apiClientConfig.host + ":" + port + path
+      case _ => apiClientConfig.scheme + "://" + apiClientConfig.host + path
+    }
 
 }

--- a/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClientConfig.scala
+++ b/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClientConfig.scala
@@ -2,7 +2,7 @@ package com.github.pedrovgs.kuronometer.free.interpreter.api
 
 case class KuronometerApiClientConfig(scheme: String = "https",
                                       host: String = "kuronometer.io",
-                                      port: Int = 80)
+                                      port: Option[Int] = None)
 
 object KuronometerApiClientConfig {
   private[api] val headers: Map[String, String] =

--- a/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/KuronometerSpec.scala
+++ b/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/KuronometerSpec.scala
@@ -30,7 +30,7 @@ class KuronometerSpec
   "Kuronometer" should "point to production" in {
     apiConfig.scheme shouldBe "https"
     apiConfig.host shouldBe "kuronometer.io"
-    apiConfig.port shouldBe 80
+    apiConfig.port shouldBe None
   }
 
   it should "returns the build report as a success even when the remote reporter fails due to any error" in {

--- a/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClientSpec.scala
+++ b/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClientSpec.scala
@@ -17,7 +17,7 @@ class KuronometerApiClientSpec
 
   private val reportBuildExecutionPath = "/buildExecution"
   private implicit def apiClientConfig =
-    KuronometerApiClientConfig(scheme, host, port)
+    KuronometerApiClientConfig(scheme, host, Some(port))
   private val apiClient = new KuronometerApiClient()
 
   "KuronometerApiClient" should "report a build execution to the correct path using a post request" in {


### PR DESCRIPTION
Closes #10 

We've changed how the API client has been configured to use an optional port instead of the original one, port 80.