### PR TITLE
Implement the http reporting as a fire and forget async task

### DIFF
--- a/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/ReporterInterpreter.scala
+++ b/kuronometer-core/src/main/scala/com/github/pedrovgs/kuronometer/free/interpreter/ReporterInterpreter.scala
@@ -20,6 +20,7 @@ class ReporterInterpreter(implicit csvReporter: CsvReporter,
   override def apply[A](fa: ReporterOp[A]): Id[A] = fa match {
     case ReportBuildExecution(buildExecution, RemoteReport) =>
       apiClient.report(buildExecution)
+      Right(buildExecution)
     case ReportBuildExecution(buildExecution, LocalReport) =>
       csvReporter.report(buildExecution)
     case GetTotalBuildExecution() => csvReporter.getTotalBuildExecutionStages

--- a/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/KuronometerSpec.scala
+++ b/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/KuronometerSpec.scala
@@ -17,6 +17,8 @@ import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class KuronometerSpec
     extends FlatSpec
@@ -38,7 +40,7 @@ class KuronometerSpec
       (apiClient
         .report(_: BuildExecution)(_: KuronometerApiClientConfig))
         .expects(build, *)
-        .returning(Left(error))
+        .returning(Future { Left(error) })
       (csvReporter.report _).expects(build).returning(Right(build))
 
       val reportedBuild = Kuronometer
@@ -54,7 +56,7 @@ class KuronometerSpec
       (apiClient
         .report(_: BuildExecution)(_: KuronometerApiClientConfig))
         .expects(build, *)
-        .returning(Right(build))
+        .returning(Future { Right(build) })
       (csvReporter.report _).expects(build).returning(Left(error))
 
       val reportedBuild = Kuronometer
@@ -71,7 +73,7 @@ class KuronometerSpec
         (apiClient
           .report(_: BuildExecution)(_: KuronometerApiClientConfig))
           .expects(*, *)
-          .returning(Right(build))
+          .returning(Future { Right(build) })
         (csvReporter.report _).expects(*).returning(Right(build))
 
         val reportedBuild = Kuronometer
@@ -89,7 +91,7 @@ class KuronometerSpec
           .report(_: BuildExecution)(_: KuronometerApiClientConfig))
           .expects(*, *)
           .never()
-          .returning(Right(build))
+          .returning(Future { Right(build) })
         (csvReporter.report _).expects(*).returning(Right(build))
 
         val reportedBuild = Kuronometer
@@ -106,7 +108,7 @@ class KuronometerSpec
       (apiClient
         .report(_: BuildExecution)(_: KuronometerApiClientConfig))
         .expects(anonymousBuild, *)
-        .returning(Right(anonymousBuild))
+        .returning(Future { Right(anonymousBuild) })
       (csvReporter.report _)
         .expects(anonymousBuild)
         .returning(Right(anonymousBuild))

--- a/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClientSpec.scala
+++ b/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClientSpec.scala
@@ -8,6 +8,7 @@ import com.github.pedrovgs.kuronometer.free.domain.BuildExecution
 import com.github.pedrovgs.kuronometer.mothers.BuildExecutionMother
 import com.github.tomakehurst.wiremock.client.WireMock._
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.Future
@@ -18,6 +19,9 @@ class KuronometerApiClientSpec
     with StubbingHttp
     with Resources
     with ScalaFutures {
+
+  implicit val defaultPatience =
+    PatienceConfig(timeout = Span(1, Seconds), interval = Span(100, Millis))
 
   private val reportBuildExecutionPath = "/buildExecution"
   private implicit def apiClientConfig =

--- a/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClientSpec.scala
+++ b/kuronometer-core/src/test/scala/com/github/pedrovgs/kuronometer/free/interpreter/api/KuronometerApiClientSpec.scala
@@ -16,7 +16,8 @@ class KuronometerApiClientSpec
     extends FlatSpec
     with Matchers
     with StubbingHttp
-    with Resources {
+    with Resources
+    with ScalaFutures {
 
   private val reportBuildExecutionPath = "/buildExecution"
   private implicit def apiClientConfig =
@@ -26,7 +27,7 @@ class KuronometerApiClientSpec
   "KuronometerApiClient" should "report a build execution to the correct path using a post request" in {
     givenTheBuildExecutionIsReportedProperly()
 
-    ScalaFutures.whenReady(report()) { _ =>
+    whenReady(report()) { _ =>
       verify(postRequestedFor(urlEqualTo(reportBuildExecutionPath)))
     }
   }
@@ -35,7 +36,7 @@ class KuronometerApiClientSpec
     givenTheBuildExecutionIsReportedProperly()
 
     val buildExecution = BuildExecutionMother.anyBuildExecution
-    ScalaFutures.whenReady(report(buildExecution)) { result =>
+    whenReady(report(buildExecution)) { result =>
       result shouldBe Right(buildExecution)
     }
   }
@@ -43,7 +44,7 @@ class KuronometerApiClientSpec
   it should "return an UnknownError if something goes wrong in server side" in {
     givenTheBuildExecutionReportFails()
 
-    ScalaFutures.whenReady(report()) { result =>
+    whenReady(report()) { result =>
       result shouldBe Left(UnknownError())
     }
   }
@@ -51,7 +52,7 @@ class KuronometerApiClientSpec
   it should "send the build execution as part of the report request serialized into json" in {
     givenTheBuildExecutionIsReportedProperly()
 
-    ScalaFutures.whenReady(report()) { _ =>
+    whenReady(report()) { _ =>
       verify(
         postRequestedFor(urlEqualTo(reportBuildExecutionPath))
           .withRequestBody(
@@ -62,8 +63,7 @@ class KuronometerApiClientSpec
   it should "send the build execution anonymously as part of the report request serialized into json" in {
     givenTheBuildExecutionIsReportedProperly()
 
-    ScalaFutures.whenReady(
-      report(BuildExecutionMother.anonymousBuildExecution)) { _ =>
+    whenReady(report(BuildExecutionMother.anonymousBuildExecution)) { _ =>
       verify(
         postRequestedFor(urlEqualTo(reportBuildExecutionPath))
           .withRequestBody(equalToJson(
@@ -74,7 +74,7 @@ class KuronometerApiClientSpec
   it should "send the accept application json header as part of the request" in {
     givenTheBuildExecutionIsReportedProperly()
 
-    ScalaFutures.whenReady(report()) { _ =>
+    whenReady(report()) { _ =>
       verify(
         postRequestedFor(urlEqualTo(reportBuildExecutionPath))
           .withHeader("Content-Type",


### PR DESCRIPTION
Closes #14 

As the Gradle plugin implementation was waiting for the server response but this is not needed we've decided to implement this request as a fire and forget speeding up the client performance when reporting a build.